### PR TITLE
Eager dominant-eigen computation during dataset ingestion

### DIFF
--- a/docs/MOTHER_TODO.md
+++ b/docs/MOTHER_TODO.md
@@ -20,7 +20,7 @@ This plan is intentionally detailed at the top and increasingly general lower do
 - [x] Implement row normalization for A matrix.
 - [x] Define behavior for zero rows.
 - [x] Implement eager Leontief compute pipeline with default degree/order 20.
-- [ ] Implement eager eigen pipeline at dataset load.
+- [x] Implement eager eigen pipeline at dataset load.
 - [x] Add focused tests for A matrix invariants.
 
 ## 3. Filter MVP (detailed)

--- a/src/data/ingest/ingestDataset.ts
+++ b/src/data/ingest/ingestDataset.ts
@@ -1,3 +1,4 @@
+import { computeDominantEigenFromFlowMatrix } from '../../engine/eigen.js';
 import {
   type Dataset,
   type NodeMeta,
@@ -163,13 +164,16 @@ export function ingestDataset(input: RawDatasetInput): Dataset {
   assertNoDuplicateCoordinates(sortedEntries);
   const normalizedEntries = sanitizeValues(sortedEntries);
 
+  const csr = buildCSR(matrix.rows, matrix.cols, normalizedEntries);
+
   return {
     version: input.version,
     nodeOrder: nodes.map((node) => node.id),
     nodeMetaById: new Map(nodes.map((node) => [node.id, node])),
     matrix: {
-      csr: buildCSR(matrix.rows, matrix.cols, normalizedEntries),
+      csr,
       csc: buildCSC(matrix.rows, matrix.cols, normalizedEntries),
     },
+    eigen: computeDominantEigenFromFlowMatrix(csr),
   };
 }

--- a/src/data/models/types.ts
+++ b/src/data/models/types.ts
@@ -35,6 +35,14 @@ export interface SparseMatrixStore {
   csc: SparseMatrixCSC;
 }
 
+
+export interface DominantEigenResult {
+  value: number;
+  vector: Float64Array<ArrayBufferLike>;
+  iterations: number;
+  converged: boolean;
+}
+
 export interface RawDatasetInput {
   version: '1.0';
   nodes: NodeMeta[];
@@ -50,4 +58,5 @@ export interface Dataset {
   nodeOrder: NodeId[];
   nodeMetaById: Map<NodeId, NodeMeta>;
   matrix: SparseMatrixStore;
+  eigen: DominantEigenResult;
 }

--- a/src/engine/eigen.ts
+++ b/src/engine/eigen.ts
@@ -1,0 +1,143 @@
+import type { SparseMatrixCSR } from '../data/models/types.js';
+import { normalizeRows } from './normalizeRows.js';
+
+export interface DominantEigenOptions {
+  maxIterations?: number;
+  tolerance?: number;
+}
+
+export interface DominantEigenResult {
+  value: number;
+  vector: Float64Array<ArrayBufferLike>;
+  iterations: number;
+  converged: boolean;
+}
+
+function assertSquare(csr: SparseMatrixCSR): void {
+  if (csr.rows !== csr.cols) {
+    throw new Error('Eigen pipeline requires a square matrix.');
+  }
+}
+
+function normalizeOptions(options?: DominantEigenOptions): Required<DominantEigenOptions> {
+  const maxIterations = options?.maxIterations ?? 100;
+  const tolerance = options?.tolerance ?? 1e-8;
+
+  if (!Number.isInteger(maxIterations) || maxIterations < 1) {
+    throw new Error('Eigen maxIterations must be a positive integer.');
+  }
+
+  if (!Number.isFinite(tolerance) || tolerance <= 0) {
+    throw new Error('Eigen tolerance must be a positive finite number.');
+  }
+
+  return { maxIterations, tolerance };
+}
+
+function l2Norm(values: Float64Array): number {
+  let sum = 0;
+  for (let i = 0; i < values.length; i += 1) {
+    sum += values[i] * values[i];
+  }
+
+  return Math.sqrt(sum);
+}
+
+function normalizeVector(values: Float64Array): Float64Array {
+  const norm = l2Norm(values);
+  const out = new Float64Array(values.length);
+
+  if (norm === 0) {
+    out.set(values);
+    return out;
+  }
+  for (let i = 0; i < values.length; i += 1) {
+    out[i] = values[i] / norm;
+  }
+
+  return out;
+}
+
+function multiplyCSRByVector(csr: SparseMatrixCSR, vector: Float64Array): Float64Array {
+  const out = new Float64Array(csr.rows);
+
+  for (let row = 0; row < csr.rows; row += 1) {
+    let sum = 0;
+    for (let idx = csr.rowPtr[row]; idx < csr.rowPtr[row + 1]; idx += 1) {
+      sum += csr.values[idx] * vector[csr.colIdx[idx]];
+    }
+    out[row] = sum;
+  }
+
+  return out;
+}
+
+function rayleighQuotient(csr: SparseMatrixCSR, vector: Float64Array): number {
+  const multiplied = multiplyCSRByVector(csr, vector);
+  let numerator = 0;
+  let denominator = 0;
+
+  for (let i = 0; i < vector.length; i += 1) {
+    numerator += vector[i] * multiplied[i];
+    denominator += vector[i] * vector[i];
+  }
+
+  if (denominator === 0) {
+    return 0;
+  }
+
+  return numerator / denominator;
+}
+
+/**
+ * Computes dominant eigenpair of a row-normalized matrix using power iteration.
+ */
+export function computeDominantEigenpair(
+  normalizedA: SparseMatrixCSR,
+  options?: DominantEigenOptions,
+): DominantEigenResult {
+  assertSquare(normalizedA);
+  const { maxIterations, tolerance } = normalizeOptions(options);
+
+  let vector: Float64Array<ArrayBufferLike> = new Float64Array(normalizedA.rows);
+  vector.fill(1 / Math.sqrt(normalizedA.rows));
+
+  let converged = false;
+  let iterations = 0;
+
+  for (let step = 1; step <= maxIterations; step += 1) {
+    const nextRaw = multiplyCSRByVector(normalizedA, vector);
+    const nextVector = normalizeVector(nextRaw);
+
+    let maxDelta = 0;
+    for (let i = 0; i < nextVector.length; i += 1) {
+      maxDelta = Math.max(maxDelta, Math.abs(nextVector[i] - vector[i]));
+    }
+
+    vector = nextVector;
+    iterations = step;
+
+    if (maxDelta <= tolerance) {
+      converged = true;
+      break;
+    }
+  }
+
+  return {
+    value: rayleighQuotient(normalizedA, vector),
+    vector,
+    iterations,
+    converged,
+  };
+}
+
+/**
+ * Convenience pipeline for computing dominant eigenpair directly from a flow matrix.
+ */
+export function computeDominantEigenFromFlowMatrix(
+  flowMatrix: SparseMatrixCSR,
+  options?: DominantEigenOptions,
+): DominantEigenResult {
+  const normalizedA = normalizeRows(flowMatrix);
+  return computeDominantEigenpair(normalizedA, options);
+}

--- a/tests/eigen.test.ts
+++ b/tests/eigen.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeDominantEigenFromFlowMatrix,
+  computeDominantEigenpair,
+} from '../src/engine/eigen.js';
+import type { SparseMatrixCSR } from '../src/data/models/types.js';
+
+describe('computeDominantEigenpair', () => {
+  it('returns dominant eigenpair for a simple diagonal matrix', () => {
+    const normalizedA: SparseMatrixCSR = {
+      rows: 2,
+      cols: 2,
+      rowPtr: Uint32Array.from([0, 1, 2]),
+      colIdx: Uint32Array.from([0, 1]),
+      values: Float64Array.from([2, 1]),
+    };
+
+    const result = computeDominantEigenpair(normalizedA, {
+      maxIterations: 200,
+      tolerance: 1e-10,
+    });
+
+    expect(result.converged).toBe(true);
+    expect(result.value).toBeCloseTo(2, 6);
+    expect(result.vector[0]).toBeCloseTo(1, 4);
+    expect(Math.abs(result.vector[1])).toBeLessThan(0.02);
+  });
+
+  it('normalizes rows for the flow-matrix convenience pipeline', () => {
+    const flowMatrix: SparseMatrixCSR = {
+      rows: 2,
+      cols: 2,
+      rowPtr: Uint32Array.from([0, 2, 3]),
+      colIdx: Uint32Array.from([0, 1, 1]),
+      values: Float64Array.from([2, 2, 3]),
+    };
+
+    const result = computeDominantEigenFromFlowMatrix(flowMatrix);
+
+    expect(result.converged).toBe(true);
+    expect(result.value).toBeCloseTo(1, 6);
+  });
+
+  it('throws for invalid options', () => {
+    const normalizedA: SparseMatrixCSR = {
+      rows: 1,
+      cols: 1,
+      rowPtr: Uint32Array.from([0, 0]),
+      colIdx: Uint32Array.from([]),
+      values: Float64Array.from([]),
+    };
+
+    expect(() => computeDominantEigenpair(normalizedA, { maxIterations: 0 })).toThrow(
+      'Eigen maxIterations must be a positive integer.',
+    );
+  });
+});

--- a/tests/ingestDataset.test.ts
+++ b/tests/ingestDataset.test.ts
@@ -35,6 +35,8 @@ describe('ingestDataset', () => {
 
     expect(dataset.matrix.csc.colPtr).toEqual(Uint32Array.from([0, 1, 2, 3]));
     expect(dataset.matrix.csc.rowIdx).toEqual(Uint32Array.from([2, 0, 1]));
+    expect(dataset.eigen.converged).toBe(true);
+    expect(dataset.eigen.value).toBeCloseTo(1, 6);
   });
 
   it('throws when duplicate matrix coordinates are present', () => {


### PR DESCRIPTION
### Motivation
- Provide a small, reliable engine to compute the dominant eigenpair of an MRIO flow matrix so datasets include ready-to-use eigen metadata for charting and analysis.
- Keep the computation lightweight and predictable by using a sparse power-iteration implementation with simple options and validation.
- Run the eigen pipeline at ingest time to surface this metadata early in the data pipeline without changing downstream module boundaries.

### Description
- Add a new sparse power-iteration utility `src/engine/eigen.ts` that computes a dominant eigenpair with option validation, convergence tracking, and a flow-matrix convenience pipeline that row-normalizes before solving using `computeDominantEigenpair` and `computeDominantEigenFromFlowMatrix`.
- Extend model types in `src/data/models/types.ts` with a `DominantEigenResult` interface and add an `eigen` field to the `Dataset` shape.
- Wire eager eigen precomputation into ingestion by computing the eigenpair from the built CSR store in `src/data/ingest/ingestDataset.ts` so each ingested dataset includes `eigen` metadata.
- Add focused unit tests in `tests/eigen.test.ts` and update `tests/ingestDataset.test.ts` to assert the eigen result is present and sensible, and update project docs to mark the TODO complete.

### Testing
- Ran `npm run typecheck` and the TypeScript check passed with no errors.
- Ran `npm test` and all automated tests passed (`tests/eigen.test.ts`, `tests/ingestDataset.test.ts`, `tests/leontief.test.ts`, `tests/normalizeRows.test.ts`), totaling 15/15 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969484ea3c833194316d741e2d9467)