### PR TITLE
Fix MRIO calculator rendering on browsers without modern DOM APIs

### DIFF
--- a/mrio_calculator.html
+++ b/mrio_calculator.html
@@ -198,6 +198,18 @@
         };
       }
 
+      function replaceWithNode(container, node) {
+        while (container.firstChild) {
+          container.removeChild(container.firstChild);
+        }
+        container.appendChild(node);
+      }
+
+      function getValue(values, row, col) {
+        if (!values || !values[row]) return 0;
+        return values[row][col] ?? 0;
+      }
+
       function renderMatrixInput(size, values) {
         const table = document.createElement('table');
         const header = document.createElement('tr');
@@ -223,14 +235,14 @@
             input.className = 'matrix-input';
             input.dataset.row = String(r);
             input.dataset.col = String(c);
-            input.value = String(values?.[r]?.[c] ?? 0);
+            input.value = String(getValue(values, r, c));
             td.appendChild(input);
             tr.appendChild(td);
           }
           table.appendChild(tr);
         }
 
-        matrixContainer.replaceChildren(table);
+        replaceWithNode(matrixContainer, table);
       }
 
       function getMatrixValues() {
@@ -261,7 +273,7 @@
           table.appendChild(tr);
         }
 
-        container.replaceChildren(table);
+        replaceWithNode(container, table);
       }
 
       function renderVector(container, vector, digits = 6) {
@@ -272,10 +284,11 @@
           name.textContent = `v${i + 1}`;
           const value = document.createElement('td');
           value.textContent = vector[i].toFixed(digits);
-          tr.append(name, value);
+          tr.appendChild(name);
+          tr.appendChild(value);
           table.appendChild(tr);
         }
-        container.replaceChildren(table);
+        replaceWithNode(container, table);
       }
 
       function runCalculations() {
@@ -312,7 +325,7 @@
         dimensionInput.value = String(size);
         const old = getMatrixValues();
         const resized = Array.from({ length: size }, (_, r) =>
-          Array.from({ length: size }, (_, c) => old[r]?.[c] ?? 0),
+          Array.from({ length: size }, (_, c) => getValue(old, r, c)),
         );
         renderMatrixInput(size, resized);
       });


### PR DESCRIPTION
### Motivation
- The inline script used newer DOM/JS APIs which prevented matrix input cells and result tables from rendering in some browsers. 
- The goal is a small compatibility fix that preserves current behavior while avoiding modern API usage that can fail at runtime.

### Description
- Add `replaceWithNode(container, node)` and use it instead of `replaceChildren` to clear and replace DOM content via `removeChild`/`appendChild` for broader compatibility. 
- Add `getValue(values, row, col)` and replace optional-chaining nested reads with it to avoid runtime/syntax issues when accessing matrix values. 
- Replace `tr.append(name, value)` with explicit `tr.appendChild(...)` calls and apply `getValue` in the matrix resize path to keep behavior identical on older engines.

### Testing
- Ran unit tests with `npm test` (Vitest) and all tests passed (`15` tests across 4 test files). 
- Executed an automated Playwright smoke script against a local `http.server` instance which confirmed matrix inputs render on load, the **Load Sample** action populates outputs, and no page errors occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986fff18408331974c2f2a98d9b4db)