### PR TITLE
Add D3 chart-builder engine primitives for graph view models

### DIFF
--- a/docs/MOTHER_TODO.md
+++ b/docs/MOTHER_TODO.md
@@ -31,8 +31,8 @@ This plan is intentionally detailed at the top and increasingly general lower do
 - [ ] Add unit tests for key filter cases.
 
 ## 4. Chart builder core + first chart (detailed)
-- [ ] Implement chart-agnostic view model creator.
-- [ ] Implement node click-to-focus neighborhood extraction.
+- [x] Implement chart-agnostic view model creator.
+- [x] Implement node click-to-focus neighborhood extraction.
 - [ ] Build first chart adapter.
 - [ ] Wire hover/click/select interactions.
 - [ ] Add simple side panel for selected node details.

--- a/src/chart-builder/adapters/d3ForceAdapter.ts
+++ b/src/chart-builder/adapters/d3ForceAdapter.ts
@@ -1,0 +1,48 @@
+import type { ChartGraphViewModel } from '../core/viewModel.js';
+
+export interface D3ForceNodeDatum {
+  id: string;
+  label: string;
+  group: string;
+  size: number;
+}
+
+export interface D3ForceLinkDatum {
+  source: string;
+  target: string;
+  value: number;
+  strength: number;
+}
+
+export interface D3ForceGraphData {
+  nodes: D3ForceNodeDatum[];
+  links: D3ForceLinkDatum[];
+}
+
+export function toD3ForceGraphData(viewModel: ChartGraphViewModel): D3ForceGraphData {
+  const maxFlow = viewModel.nodes.reduce((max, node) => {
+    const nodeFlow = node.totalInFlow + node.totalOutFlow;
+    return nodeFlow > max ? nodeFlow : max;
+  }, 0);
+
+  const nodes: D3ForceNodeDatum[] = viewModel.nodes.map((node) => {
+    const rawFlow = node.totalInFlow + node.totalOutFlow;
+    const normalized = maxFlow > 0 ? rawFlow / maxFlow : 0;
+
+    return {
+      id: node.id,
+      label: node.label,
+      group: node.region ?? node.sector ?? 'default',
+      size: 8 + (normalized * 20),
+    };
+  });
+
+  const links: D3ForceLinkDatum[] = viewModel.links.map((link) => ({
+    source: link.source,
+    target: link.target,
+    value: link.value,
+    strength: Math.max(0.05, Math.min(1, link.value)),
+  }));
+
+  return { nodes, links };
+}

--- a/src/chart-builder/core/neighborhood.ts
+++ b/src/chart-builder/core/neighborhood.ts
@@ -1,0 +1,81 @@
+import type { NodeId } from '../../data/models/types.js';
+import type { ChartGraphViewModel, ChartLinkViewModel } from './viewModel.js';
+
+export interface NeighborhoodOptions {
+  direction?: 'outbound' | 'inbound' | 'both';
+  depth?: number;
+  maxNodes?: number;
+}
+
+export interface NeighborhoodResult {
+  centerNodeId: NodeId;
+  nodeIds: NodeId[];
+  links: ChartLinkViewModel[];
+}
+
+export function extractNeighborhood(
+  viewModel: ChartGraphViewModel,
+  centerNodeId: NodeId,
+  options: NeighborhoodOptions = {},
+): NeighborhoodResult {
+  const direction = options.direction ?? 'both';
+  const depth = options.depth ?? 1;
+  const maxNodes = options.maxNodes ?? 200;
+
+  if (!Number.isInteger(depth) || depth < 0) {
+    throw new Error('depth must be a non-negative integer.');
+  }
+
+  if (!Number.isInteger(maxNodes) || maxNodes <= 0) {
+    throw new Error('maxNodes must be a positive integer.');
+  }
+
+  const nodeExists = viewModel.nodes.some((node) => node.id === centerNodeId);
+  if (!nodeExists) {
+    throw new Error(`Unknown node id: ${centerNodeId}`);
+  }
+
+  const selectedNodeIds = new Set<NodeId>([centerNodeId]);
+  let frontier: NodeId[] = [centerNodeId];
+
+  for (let level = 0; level < depth; level += 1) {
+    const nextFrontier: NodeId[] = [];
+
+    for (const current of frontier) {
+      for (const link of viewModel.links) {
+        const outbound = link.source === current;
+        const inbound = link.target === current;
+
+        if ((direction === 'both' || direction === 'outbound') && outbound) {
+          if (!selectedNodeIds.has(link.target) && selectedNodeIds.size < maxNodes) {
+            selectedNodeIds.add(link.target);
+            nextFrontier.push(link.target);
+          }
+        }
+
+        if ((direction === 'both' || direction === 'inbound') && inbound) {
+          if (!selectedNodeIds.has(link.source) && selectedNodeIds.size < maxNodes) {
+            selectedNodeIds.add(link.source);
+            nextFrontier.push(link.source);
+          }
+        }
+      }
+    }
+
+    if (nextFrontier.length === 0 || selectedNodeIds.size >= maxNodes) {
+      break;
+    }
+
+    frontier = nextFrontier;
+  }
+
+  const links = viewModel.links.filter(
+    (link) => selectedNodeIds.has(link.source) && selectedNodeIds.has(link.target),
+  );
+
+  return {
+    centerNodeId,
+    nodeIds: Array.from(selectedNodeIds),
+    links,
+  };
+}

--- a/src/chart-builder/core/viewModel.ts
+++ b/src/chart-builder/core/viewModel.ts
@@ -1,0 +1,98 @@
+import type { Dataset, NodeId } from '../../data/models/types.js';
+
+export interface ChartNodeViewModel {
+  id: NodeId;
+  label: string;
+  region?: string;
+  sector?: string;
+  outDegree: number;
+  inDegree: number;
+  totalOutFlow: number;
+  totalInFlow: number;
+}
+
+export interface ChartLinkViewModel {
+  source: NodeId;
+  target: NodeId;
+  value: number;
+}
+
+export interface ChartGraphViewModel {
+  nodes: ChartNodeViewModel[];
+  links: ChartLinkViewModel[];
+}
+
+export interface BuildChartViewModelOptions {
+  minLinkValue?: number;
+  maxLinks?: number;
+}
+
+export function buildChartGraphViewModel(
+  dataset: Dataset,
+  options: BuildChartViewModelOptions = {},
+): ChartGraphViewModel {
+  const minLinkValue = options.minLinkValue ?? 0;
+  const maxLinks = options.maxLinks;
+
+  if (minLinkValue < 0 || !Number.isFinite(minLinkValue)) {
+    throw new Error('minLinkValue must be a finite number greater than or equal to 0.');
+  }
+
+  if (maxLinks !== undefined && (!Number.isInteger(maxLinks) || maxLinks <= 0)) {
+    throw new Error('maxLinks must be a positive integer when provided.');
+  }
+
+  const links: ChartLinkViewModel[] = [];
+  const { csr } = dataset.matrix;
+
+  for (let row = 0; row < csr.rows; row += 1) {
+    const sourceId = dataset.nodeOrder[row];
+
+    for (let idx = csr.rowPtr[row]; idx < csr.rowPtr[row + 1]; idx += 1) {
+      const value = csr.values[idx];
+      if (value < minLinkValue) {
+        continue;
+      }
+
+      const targetId = dataset.nodeOrder[csr.colIdx[idx]];
+      links.push({ source: sourceId, target: targetId, value });
+    }
+  }
+
+  if (maxLinks !== undefined && links.length > maxLinks) {
+    links.sort((a, b) => b.value - a.value);
+    links.length = maxLinks;
+  }
+
+  const outDegree = new Map<NodeId, number>();
+  const inDegree = new Map<NodeId, number>();
+  const totalOutFlow = new Map<NodeId, number>();
+  const totalInFlow = new Map<NodeId, number>();
+
+  for (const link of links) {
+    outDegree.set(link.source, (outDegree.get(link.source) ?? 0) + 1);
+    inDegree.set(link.target, (inDegree.get(link.target) ?? 0) + 1);
+    totalOutFlow.set(link.source, (totalOutFlow.get(link.source) ?? 0) + link.value);
+    totalInFlow.set(link.target, (totalInFlow.get(link.target) ?? 0) + link.value);
+  }
+
+  const nodes: ChartNodeViewModel[] = dataset.nodeOrder.map((id) => {
+    const meta = dataset.nodeMetaById.get(id);
+    if (!meta) {
+      throw new Error(`Missing node metadata for node id: ${id}`);
+    }
+
+    return {
+      id,
+      label: meta.label,
+      region: meta.region,
+      sector: meta.sector,
+      outDegree: outDegree.get(id) ?? 0,
+      inDegree: inDegree.get(id) ?? 0,
+      totalOutFlow: totalOutFlow.get(id) ?? 0,
+      totalInFlow: totalInFlow.get(id) ?? 0,
+    };
+  });
+
+  return { nodes, links };
+}

--- a/tests/chartBuilderD3Engine.test.ts
+++ b/tests/chartBuilderD3Engine.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { toD3ForceGraphData } from '../src/chart-builder/adapters/d3ForceAdapter.js';
+import { extractNeighborhood } from '../src/chart-builder/core/neighborhood.js';
+import { buildChartGraphViewModel } from '../src/chart-builder/core/viewModel.js';
+import { ingestDataset } from '../src/data/ingest/ingestDataset.js';
+import type { RawDatasetInput } from '../src/data/models/types.js';
+
+const input: RawDatasetInput = {
+  version: '1.0',
+  nodes: [
+    { id: 'A', label: 'Agriculture', region: 'Coast' },
+    { id: 'B', label: 'Manufacturing', region: 'Coast' },
+    { id: 'C', label: 'Services', region: 'Highlands' },
+    { id: 'D', label: 'Transport', region: 'Amazon' },
+  ],
+  matrix: {
+    rows: 4,
+    cols: 4,
+    entries: [
+      { row: 0, col: 1, value: 8 },
+      { row: 1, col: 2, value: 3 },
+      { row: 2, col: 0, value: 2 },
+      { row: 1, col: 3, value: 1 },
+    ],
+  },
+};
+
+describe('D3 chart builder engine', () => {
+  it('builds a chart view model and supports max-link filtering', () => {
+    const dataset = ingestDataset(input);
+
+    const viewModel = buildChartGraphViewModel(dataset, { minLinkValue: 2, maxLinks: 2 });
+
+    expect(viewModel.nodes).toHaveLength(4);
+    expect(viewModel.links).toHaveLength(2);
+    expect(viewModel.links[0].value).toBeGreaterThanOrEqual(viewModel.links[1].value);
+
+    const nodeB = viewModel.nodes.find((node) => node.id === 'B');
+    expect(nodeB?.outDegree).toBe(1);
+    expect(nodeB?.totalOutFlow).toBeCloseTo(3);
+  });
+
+  it('maps chart view model to D3 force data', () => {
+    const dataset = ingestDataset(input);
+    const viewModel = buildChartGraphViewModel(dataset);
+
+    const d3Data = toD3ForceGraphData(viewModel);
+
+    expect(d3Data.nodes).toHaveLength(4);
+    expect(d3Data.links).toHaveLength(4);
+    expect(d3Data.nodes.every((node) => node.size >= 8)).toBe(true);
+    expect(d3Data.links.every((link) => link.strength >= 0.05 && link.strength <= 1)).toBe(true);
+  });
+
+  it('extracts inbound and outbound neighborhoods for click-to-focus', () => {
+    const dataset = ingestDataset(input);
+    const viewModel = buildChartGraphViewModel(dataset);
+
+    const neighborhood = extractNeighborhood(viewModel, 'B', { direction: 'both', depth: 1 });
+
+    expect(neighborhood.centerNodeId).toBe('B');
+    expect(neighborhood.nodeIds.sort()).toEqual(['A', 'B', 'C', 'D']);
+    expect(neighborhood.links).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a chart-agnostic view-model layer to map ingested MRIO sparse matrices into node/link structures for chart builders. 
- Enable click-to-focus neighborhood extraction and a simple adapter for D3 force graphs so the UI can render and interact with networks without embedding matrix logic.

### Description
- Added `src/chart-builder/core/viewModel.ts` implementing `buildChartGraphViewModel` that produces `nodes`/`links` with per-node degree and flow metrics and supports `minLinkValue` and `maxLinks` options.
- Added `src/chart-builder/core/neighborhood.ts` implementing `extractNeighborhood` for inbound/outbound/both traversal with `depth` and `maxNodes` controls.
- Added `src/chart-builder/adapters/d3ForceAdapter.ts` implementing `toD3ForceGraphData` to convert the core view model to D3-friendly node/link datum (normalized node `size` and bounded link `strength`).
- Added focused tests in `tests/chartBuilderD3Engine.test.ts` and updated `docs/MOTHER_TODO.md` to mark the view-model and neighborhood tasks complete.

### Testing
- Ran `npm test` which executes `vitest`; all tests passed (5 test files, 18 tests, all green).
- Ran type check via `npm run typecheck` which runs `tsc --noEmit` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986ff719b48331a98f884dc06f8124)