### PR TITLE
Add MVP text filter parser, AST evaluator, and unit tests

### DIFF
--- a/docs/MOTHER_TODO.md
+++ b/docs/MOTHER_TODO.md
@@ -24,11 +24,11 @@ This plan is intentionally detailed at the top and increasingly general lower do
 - [x] Add focused tests for A matrix invariants.
 
 ## 3. Filter MVP (detailed)
-- [ ] Define compact grammar for text filters.
-- [ ] Implement tokenizer + parser.
-- [ ] Compile filter AST to evaluator.
-- [ ] Add user-facing invalid filter errors.
-- [ ] Add unit tests for key filter cases.
+- [x] Define compact grammar for text filters.
+- [x] Implement tokenizer + parser.
+- [x] Compile filter AST to evaluator.
+- [x] Add user-facing invalid filter errors.
+- [x] Add unit tests for key filter cases.
 
 ## 4. Chart builder core + first chart (detailed)
 - [ ] Implement chart-agnostic view model creator.
@@ -69,4 +69,3 @@ This plan is intentionally detailed at the top and increasingly general lower do
 - [ ] Evaluate WASM acceleration only if JS+worker path becomes limiting.
 - [ ] Consider collaborative features and saved analysis sessions.
 - [ ] Consider larger ecosystem integration once MVP is stable.
-

--- a/src/filters/filterEvaluator.ts
+++ b/src/filters/filterEvaluator.ts
@@ -1,0 +1,124 @@
+import type { NodeMeta } from '../data/models/types.js';
+import { parseFilter } from './filterParser.js';
+import type { ComparisonOperator, FilterAst, FilterValue } from './filterTypes.js';
+
+export type NodeFilterEvaluator = (node: NodeMeta) => boolean;
+
+export function compileFilter(ast: FilterAst): NodeFilterEvaluator {
+  return (node) => evaluateNode(ast, node);
+}
+
+export function buildFilterEvaluator(expression: string): NodeFilterEvaluator {
+  return compileFilter(parseFilter(expression));
+}
+
+function evaluateNode(ast: FilterAst, node: NodeMeta): boolean {
+  switch (ast.type) {
+    case 'and':
+      return evaluateNode(ast.left, node) && evaluateNode(ast.right, node);
+    case 'or':
+      return evaluateNode(ast.left, node) || evaluateNode(ast.right, node);
+    case 'not':
+      return !evaluateNode(ast.operand, node);
+    case 'comparison':
+      return evaluateComparison(readFieldValue(node, ast.field), ast.operator, ast.value);
+    default:
+      return false;
+  }
+}
+
+function readFieldValue(node: NodeMeta, field: string): FilterValue {
+  if (field === 'id' || field === 'label' || field === 'region' || field === 'sector') {
+    return node[field] ?? null;
+  }
+
+  return (node.attributes?.[field] as FilterValue | undefined) ?? null;
+}
+
+function evaluateComparison(left: FilterValue, operator: ComparisonOperator, right: FilterValue): boolean {
+  if (operator === ':') {
+    const leftText = normalizeString(left);
+    const rightText = normalizeString(right);
+    if (leftText === null || rightText === null) {
+      return false;
+    }
+
+    return leftText.includes(rightText);
+  }
+
+  const leftNumber = asNumber(left);
+  const rightNumber = asNumber(right);
+
+  if (leftNumber !== null && rightNumber !== null) {
+    return compareNumbers(leftNumber, rightNumber, operator);
+  }
+
+  if (operator === '>' || operator === '>=' || operator === '<' || operator === '<=') {
+    return false;
+  }
+
+  const leftText = normalizeComparable(left);
+  const rightText = normalizeComparable(right);
+
+  if (operator === '=') {
+    return leftText === rightText;
+  }
+
+  if (operator === '!=') {
+    return leftText !== rightText;
+  }
+
+  return false;
+}
+
+function compareNumbers(left: number, right: number, operator: ComparisonOperator): boolean {
+  switch (operator) {
+    case '=':
+      return left === right;
+    case '!=':
+      return left !== right;
+    case '>':
+      return left > right;
+    case '>=':
+      return left >= right;
+    case '<':
+      return left < right;
+    case '<=':
+      return left <= right;
+    default:
+      return false;
+  }
+}
+
+function asNumber(value: FilterValue): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function normalizeString(value: FilterValue): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return String(value).toLowerCase();
+}
+
+function normalizeComparable(value: FilterValue): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'string') {
+    return value.toLowerCase();
+  }
+
+  return String(value);
+}

--- a/src/filters/filterParser.ts
+++ b/src/filters/filterParser.ts
@@ -1,0 +1,341 @@
+import type { ComparisonOperator, FilterAst, FilterValue } from './filterTypes.js';
+
+type TokenKind =
+  | 'identifier'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'null'
+  | 'operator'
+  | 'and'
+  | 'or'
+  | 'not'
+  | 'lparen'
+  | 'rparen'
+  | 'eof';
+
+interface Token {
+  kind: TokenKind;
+  value: string;
+  position: number;
+}
+
+const twoCharOperators = new Set(['!=', '>=', '<=']);
+const oneCharOperators = new Set(['=', '>', '<', ':']);
+
+export class FilterSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FilterSyntaxError';
+  }
+}
+
+class Tokenizer {
+  private index = 0;
+
+  constructor(private readonly input: string) {}
+
+  nextToken(): Token {
+    this.skipWhitespace();
+
+    if (this.index >= this.input.length) {
+      return { kind: 'eof', value: '', position: this.index };
+    }
+
+    const start = this.index;
+    const char = this.input[this.index];
+
+    if (char === '(') {
+      this.index += 1;
+      return { kind: 'lparen', value: '(', position: start };
+    }
+
+    if (char === ')') {
+      this.index += 1;
+      return { kind: 'rparen', value: ')', position: start };
+    }
+
+    if (char === '"' || char === "'") {
+      return this.readString(char);
+    }
+
+    const maybeTwoCharOperator = this.input.slice(this.index, this.index + 2);
+    if (twoCharOperators.has(maybeTwoCharOperator)) {
+      this.index += 2;
+      return { kind: 'operator', value: maybeTwoCharOperator, position: start };
+    }
+
+    if (oneCharOperators.has(char)) {
+      this.index += 1;
+      return { kind: 'operator', value: char, position: start };
+    }
+
+    if (this.isDigit(char) || (char === '-' && this.isDigit(this.peek(1)))) {
+      return this.readNumber();
+    }
+
+    if (this.isIdentifierStart(char)) {
+      return this.readIdentifierOrKeyword();
+    }
+
+    throw new FilterSyntaxError(`Unexpected character "${char}" at position ${start}.`);
+  }
+
+  private readString(quote: string): Token {
+    const start = this.index;
+    this.index += 1;
+    let output = '';
+
+    while (this.index < this.input.length) {
+      const current = this.input[this.index];
+
+      if (current === '\\') {
+        const escaped = this.peek(1);
+        if (escaped === undefined) {
+          throw new FilterSyntaxError(`Unterminated string at position ${start}.`);
+        }
+
+        output += escaped;
+        this.index += 2;
+        continue;
+      }
+
+      if (current === quote) {
+        this.index += 1;
+        return { kind: 'string', value: output, position: start };
+      }
+
+      output += current;
+      this.index += 1;
+    }
+
+    throw new FilterSyntaxError(`Unterminated string at position ${start}.`);
+  }
+
+  private readNumber(): Token {
+    const start = this.index;
+    if (this.input[this.index] === '-') {
+      this.index += 1;
+    }
+
+    while (this.isDigit(this.input[this.index])) {
+      this.index += 1;
+    }
+
+    if (this.input[this.index] === '.') {
+      this.index += 1;
+      while (this.isDigit(this.input[this.index])) {
+        this.index += 1;
+      }
+    }
+
+    return {
+      kind: 'number',
+      value: this.input.slice(start, this.index),
+      position: start,
+    };
+  }
+
+  private readIdentifierOrKeyword(): Token {
+    const start = this.index;
+    this.index += 1;
+
+    while (this.isIdentifierPart(this.input[this.index])) {
+      this.index += 1;
+    }
+
+    const raw = this.input.slice(start, this.index);
+    const normalized = raw.toLowerCase();
+
+    if (normalized === 'and') {
+      return { kind: 'and', value: raw, position: start };
+    }
+
+    if (normalized === 'or') {
+      return { kind: 'or', value: raw, position: start };
+    }
+
+    if (normalized === 'not') {
+      return { kind: 'not', value: raw, position: start };
+    }
+
+    if (normalized === 'true' || normalized === 'false') {
+      return { kind: 'boolean', value: normalized, position: start };
+    }
+
+    if (normalized === 'null') {
+      return { kind: 'null', value: normalized, position: start };
+    }
+
+    return { kind: 'identifier', value: raw, position: start };
+  }
+
+  private skipWhitespace(): void {
+    while (this.index < this.input.length && /\s/.test(this.input[this.index])) {
+      this.index += 1;
+    }
+  }
+
+  private peek(offset: number): string | undefined {
+    return this.input[this.index + offset];
+  }
+
+  private isDigit(char: string | undefined): boolean {
+    return typeof char === 'string' && char >= '0' && char <= '9';
+  }
+
+  private isIdentifierStart(char: string | undefined): boolean {
+    return typeof char === 'string' && /[A-Za-z_]/.test(char);
+  }
+
+  private isIdentifierPart(char: string | undefined): boolean {
+    return typeof char === 'string' && /[A-Za-z0-9_.]/.test(char);
+  }
+}
+
+class Parser {
+  private current: Token;
+
+  constructor(private readonly tokenizer: Tokenizer) {
+    this.current = tokenizer.nextToken();
+  }
+
+  parse(): FilterAst {
+    const firstToken = this.current;
+    if (firstToken.kind === 'eof') {
+      throw new FilterSyntaxError('Filter cannot be empty.');
+    }
+
+    const expression = this.parseOrExpression();
+
+    if (this.current.kind !== 'eof') {
+      throw new FilterSyntaxError(
+        `Unexpected token "${this.current.value}" at position ${this.current.position}.`,
+      );
+    }
+
+    return expression;
+  }
+
+  private parseOrExpression(): FilterAst {
+    let node = this.parseAndExpression();
+
+    while (this.current.kind === 'or') {
+      this.advance();
+      const right = this.parseAndExpression();
+      node = { type: 'or', left: node, right };
+    }
+
+    return node;
+  }
+
+  private parseAndExpression(): FilterAst {
+    let node = this.parseUnaryExpression();
+
+    while (this.current.kind === 'and') {
+      this.advance();
+      const right = this.parseUnaryExpression();
+      node = { type: 'and', left: node, right };
+    }
+
+    return node;
+  }
+
+  private parseUnaryExpression(): FilterAst {
+    if (this.current.kind === 'not') {
+      this.advance();
+      return { type: 'not', operand: this.parseUnaryExpression() };
+    }
+
+    return this.parsePrimaryExpression();
+  }
+
+  private parsePrimaryExpression(): FilterAst {
+    if (this.current.kind === 'lparen') {
+      this.advance();
+      const inner = this.parseOrExpression();
+      this.expect('rparen', 'Expected closing ")".');
+      this.advance();
+      return inner;
+    }
+
+    return this.parseComparison();
+  }
+
+  private parseComparison(): FilterAst {
+    const fieldToken = this.expect('identifier', 'Expected field name in comparison expression.');
+    this.advance();
+
+    const operatorToken = this.expect('operator', 'Expected operator after field name.');
+    const operator = operatorToken.value as ComparisonOperator;
+
+    if (!['=', '!=', '>', '>=', '<', '<=', ':'].includes(operator)) {
+      throw new FilterSyntaxError(
+        `Unsupported operator "${operator}" at position ${operatorToken.position}.`,
+      );
+    }
+
+    this.advance();
+    const value = this.parseValue();
+
+    return {
+      type: 'comparison',
+      field: fieldToken.value,
+      operator,
+      value,
+    };
+  }
+
+  private parseValue(): FilterValue {
+    const token = this.current;
+
+    if (token.kind === 'string') {
+      this.advance();
+      return token.value;
+    }
+
+    if (token.kind === 'number') {
+      this.advance();
+      const parsed = Number(token.value);
+      if (!Number.isFinite(parsed)) {
+        throw new FilterSyntaxError(`Invalid number "${token.value}" at position ${token.position}.`);
+      }
+
+      return parsed;
+    }
+
+    if (token.kind === 'boolean') {
+      this.advance();
+      return token.value === 'true';
+    }
+
+    if (token.kind === 'null') {
+      this.advance();
+      return null;
+    }
+
+    if (token.kind === 'identifier') {
+      this.advance();
+      return token.value;
+    }
+
+    throw new FilterSyntaxError(`Expected value at position ${token.position}.`);
+  }
+
+  private expect(kind: TokenKind, message: string): Token {
+    if (this.current.kind !== kind) {
+      throw new FilterSyntaxError(message);
+    }
+
+    return this.current;
+  }
+
+  private advance(): void {
+    this.current = this.tokenizer.nextToken();
+  }
+}
+
+export function parseFilter(input: string): FilterAst {
+  const parser = new Parser(new Tokenizer(input));
+  return parser.parse();
+}

--- a/src/filters/filterTypes.ts
+++ b/src/filters/filterTypes.ts
@@ -1,0 +1,23 @@
+export type FilterValue = string | number | boolean | null;
+
+export type ComparisonOperator = '=' | '!=' | '>' | '>=' | '<' | '<=' | ':';
+
+export interface ComparisonNode {
+  type: 'comparison';
+  field: string;
+  operator: ComparisonOperator;
+  value: FilterValue;
+}
+
+export interface NotNode {
+  type: 'not';
+  operand: FilterAst;
+}
+
+export interface LogicalNode {
+  type: 'and' | 'or';
+  left: FilterAst;
+  right: FilterAst;
+}
+
+export type FilterAst = ComparisonNode | NotNode | LogicalNode;

--- a/tests/filterEvaluator.test.ts
+++ b/tests/filterEvaluator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NodeMeta } from '../src/data/models/types.js';
+import { buildFilterEvaluator } from '../src/filters/filterEvaluator.js';
+import { FilterSyntaxError, parseFilter } from '../src/filters/filterParser.js';
+
+const node: NodeMeta = {
+  id: 'N1',
+  label: 'Steel Manufacturing',
+  region: 'EU',
+  sector: 'Manufacturing',
+  attributes: {
+    score: 42,
+    active: true,
+    owner: 'TeamA',
+  },
+};
+
+describe('parseFilter', () => {
+  it('parses compound expressions with precedence and parentheses', () => {
+    const ast = parseFilter('region = EU and (score >= 40 or not active = true)');
+    expect(ast.type).toBe('and');
+  });
+
+  it('throws user-facing syntax errors for invalid expressions', () => {
+    expect(() => parseFilter('region = ')).toThrow(FilterSyntaxError);
+    expect(() => parseFilter('region @@ EU')).toThrow('Unexpected character "@"');
+    expect(() => parseFilter('')).toThrow('Filter cannot be empty.');
+  });
+});
+
+describe('buildFilterEvaluator', () => {
+  it('evaluates numeric and string comparisons', () => {
+    expect(buildFilterEvaluator('score >= 40')(node)).toBe(true);
+    expect(buildFilterEvaluator('score < 40')(node)).toBe(false);
+    expect(buildFilterEvaluator('region = eu')(node)).toBe(true);
+  });
+
+  it('supports contains operator and attribute lookups', () => {
+    expect(buildFilterEvaluator('label : "steel"')(node)).toBe(true);
+    expect(buildFilterEvaluator('owner = TeamA')(node)).toBe(true);
+    expect(buildFilterEvaluator('owner != TeamB')(node)).toBe(true);
+  });
+
+  it('supports not/and/or composition', () => {
+    expect(buildFilterEvaluator('region = EU and not owner = TeamB')(node)).toBe(true);
+    expect(buildFilterEvaluator('region = APAC or owner = TeamA')(node)).toBe(true);
+    expect(buildFilterEvaluator('region = APAC and owner = TeamA')(node)).toBe(false);
+  });
+
+  it('returns false when fields are missing for comparison operators', () => {
+    expect(buildFilterEvaluator('missingField = anything')(node)).toBe(false);
+    expect(buildFilterEvaluator('missingField > 1')(node)).toBe(false);
+    expect(buildFilterEvaluator('missingField : value')(node)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a small, maintainable text-filter MVP so datasets can be filtered in the UI without shipping a full SQL-like engine. 
- Keep filter logic isolated under `src/filters/` per the project architecture and expose clear, user-facing syntax errors for malformed input.

### Description
- Add a compact filter AST and types in `src/filters/filterTypes.ts` to represent comparisons, `not`, and `and/or` logical nodes. 
- Implement a tokenizer + precedence-aware parser with `FilterSyntaxError` in `src/filters/filterParser.ts` supporting identifiers, strings, numbers, operators, parentheses, and `and`/`or`/`not` keywords. 
- Implement AST compilation/evaluation in `src/filters/filterEvaluator.ts` that evaluates against `NodeMeta` core fields and `attributes`, supports numeric and string comparisons, contains operator `:`, and handles missing fields safely. 
- Add focused unit tests in `tests/filterEvaluator.test.ts` and update `docs/MOTHER_TODO.md` to mark the Filter MVP items complete.

### Testing
- Ran `npm test` and the full test suite passed, including the new `filterEvaluator` tests. 
- Ran `npm run typecheck` and TypeScript type checking completed without errors. 
- The changes are covered by the added unit tests which exercise parser errors, operator precedence, numeric/string comparisons, contains behavior, and missing-field handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986df9e24c83318dd20f4ac693d3e6)